### PR TITLE
update quorum and geth version

### DIFF
--- a/3nodes/genesis.json
+++ b/3nodes/genesis.json
@@ -21,12 +21,19 @@
     "homesteadBlock": 0,
     "byzantiumBlock": 0,
     "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
     "chainId": 10,
     "eip150Block": 0,
     "eip155Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "eip158Block": 0,
-    "maxCodeSize": 35,
+    "maxCodeSizeConfig" : [
+      {
+        "block" : 0,
+        "size" : 32
+      }
+    ],
     "isQuorum": true
   },
   "difficulty": "0x0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 
-# QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:2.3.0
+# QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:20.10.0
 # To use Remix, set QUORUM_GETH_ARGS="--rpccorsdomain https://remix.ethereum.org"
-version: "3.6"
+version: "3.8"
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:2.3.0}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:20.10.0}"
   expose:
     - "21000"
     - "50400"
@@ -35,6 +35,7 @@ x-quorum-def:
       GETH_ARGS_raft="--raft --raftport 50400"
       geth --datadir $${DDIR} init $${GENESIS_FILE}
       geth \
+        --allow-insecure-unlock \
         --identity node$${NODE_ID}-raft \
         --datadir $${DDIR} \
         --permissioned \


### PR DESCRIPTION
Updating quorum version from 2.3 => 20.10.0 

migrating with truffle v5.x could be buggy, try v4.x instead